### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,9 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!,except:[:index,:show]
-  
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
+    @items = Item.order('created_at DESC')
+    @item = Item.find(1)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order('created_at DESC')
-    @item = Item.find(1)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,11 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :sales_status
+  belongs_to :shipping_fee_status
+  belongs_to :prefecture
+  belongs_to :scheduled_derivery
   belongs_to :user
-  belongs_to :category, :sales_status, :shipping_fee_status, :prefecture, :scheduled_derivery
   has_one_attached :image
   with_options presence: true do
     validates  :name

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   belongs_to :sales_status
   belongs_to :shipping_fee_status
   belongs_to :prefecture
-  belongs_to :scheduled_derivery
+  belongs_to :scheduled_delivery
   belongs_to :user
   has_one_attached :image
   with_options presence: true do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,7 +156,7 @@
       </li>
       <% end %>
 
-      <% if @items == nil %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,26 +125,27 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <%# <% if item.order %> 
+          <%# <div class='sold-out'> %>
+             <%# <span>Sold Out!!</span> %>
+          <%# </div>  %>
+          <%# <% end %> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +154,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,8 +175,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,8 +156,7 @@
       </li>
       <% end %>
 
-      <% if @items %>
-      <% else %>
+      <% if @items == nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -64,7 +64,7 @@ describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price Half-width number')
       end
       it 'priceが300~9999999の範囲外では登録できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price Out of setting range')
         @item.price = 100


### PR DESCRIPTION
#What
出品された商品をトップページに一覧で表示させる機能の実装。
#Why
トップページの商品一覧から画像、商品名、価格、配送料の負担を確認できるようにするため。
※売却済みの商品に「sold out」の文字が表示させる機能の実装はまだしておりません。

商品一覧表示機能のGIF（ログイン状態およびログアウト状態でも商品一覧を見ることができる様子）
https://gyazo.com/695947586441ed115e1f8cf28e8aee88